### PR TITLE
flatcar-jitsi.sh: bump to stable-7882

### DIFF
--- a/flatcar-jitsi.sh
+++ b/flatcar-jitsi.sh
@@ -16,7 +16,7 @@ DEST_DIR=~/jitsi-docker
 
 # Use a release version / tag from https://github.com/jitsi/docker-jitsi-meet
 #  otherwise the unstable nightly docker images will be used
-JITSI_VERSION="${JITSI_VERSION:-stable-7648-4}"
+JITSI_VERSION="${JITSI_VERSION:-stable-7882}"
 
 mkdir -p "${DEST_DIR}"
 cd ${DEST_DIR}
@@ -46,6 +46,8 @@ sed -i "s,^CONFIG=.*,CONFIG=${DEST_DIR}/__jitsi_docker_config__," .env
 
 cat "${RSRC_DIR}/flatcar.env" >> .env
 
+# add to .env to ease upgrade once deployed
+echo "JITSI_IMAGE_VERSION=${JITSI_VERSION}" >> .env
 
 # Start the services temporatily so we can create the moderator user
 docker-compose -f docker-compose.yml -f jibri.yml up -d


### PR DESCRIPTION
This change bumps the Jitsi docker image release to stable-7882, which is latest and greatest at the time of writing. It also adds ´JITSI_IMAGE_VERSION´ to the ´.env` file to ease upgrading once deployed.