### PR TITLE
Fix JITSI_VERSION generation and empty branding

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -71,6 +71,8 @@ else
     base_url="https://raw.githubusercontent.com/jitsi/docker-jitsi-meet/${version}"
 fi
 
+echo "$version">JITSI_VERSION
+
 branding_patch="resources/branding-docker-compose.yml.patch"
 if [ "$branding" = "true" ] ; then
   test_branding_patch "${base_url}" "${branding_patch}"

--- a/jitsi-install.sh
+++ b/jitsi-install.sh
@@ -99,7 +99,7 @@ cp "${INSTALLER_DIR}/env.example" \
 
 cd "${DEST_DIR}"
 
-git apply branding-docker-compose.yml.patch
+git apply branding-docker-compose.yml.patch --allow-empty
 
 mv env.example .env
 ./gen-passwords.sh

--- a/resources/empty-branding-docker-compose.yml.patch
+++ b/resources/empty-branding-docker-compose.yml.patch
@@ -1,4 +1,1 @@
 diff --git docker-compose.yml docker-compose.yml
-index 22261bb..ee6f1e5 100644
---- a/docker-compose.yml
-+++ b/docker-compose.yml


### PR DESCRIPTION
This PR creates `JITSI_VERSION` once again, which was lost in an earlier change. It also fixes an issue with the "empty branding" patch so non-branded Jitst can be provisioned once again.